### PR TITLE
Restore the "isEmergency" method removed in AOSP r9 merge.

### DIFF
--- a/src/java/com/android/internal/telephony/PhoneSwitcher.java
+++ b/src/java/com/android/internal/telephony/PhoneSwitcher.java
@@ -622,7 +622,20 @@ public class PhoneSwitcher extends Handler {
         }
     }
 
-    private boolean isInEmergencyCallbackMode() {
+    protected boolean isEmergency() {
+        if (isInEmergencyCallbackMode()) return true;
+        for (Phone p : mPhones) {
+            if (p == null) continue;
+            if (p.isInEmergencyCall()) return true;
+            Phone imsPhone = p.getImsPhone();
+            if (imsPhone != null && imsPhone.isInEmergencyCall()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean isInEmergencyCallbackMode() {
         for (Phone p : mPhones) {
             if (p == null) continue;
             if (p.isInEcm()) return true;


### PR DESCRIPTION
QTI telephony still requires this method to be present.

Change-Id: Ic59332a3be0425a838332118b092fe0d984eabf2